### PR TITLE
Added support for copying translated text to clipboard

### DIFF
--- a/source/App.cpp
+++ b/source/App.cpp
@@ -805,7 +805,8 @@ void App::ShowHelp()
 	msg += "Show original image - Hold UP ARROW\n";
 	msg += "Show pre translated OCR results - Hold DOWN ARROW\n";
 	msg += "To look up kanji from original - Shift-Right click kanji on original image\n";
-	msg += "To copy original text - Right click on original text block\n";
+	msg += "To copy translated text - Right click on translated text block\n";
+	msg += "To copy original text - Hold DOWN ARROW and right click on original text block\n";
 	msg += "Take screenshot - S\n";
 	string title = "UGT "+m_version+" - Hotkeys";
 

--- a/source/TextAreaComponent.cpp
+++ b/source/TextAreaComponent.cpp
@@ -460,14 +460,22 @@ void TextAreaComponent::OnTouchStart(VariantList *pVList)
 		return;
 	}
 	
-	
-	if (! (GetKeyState(VK_SHIFT) & 0x8000))
+	if (GetKeyState(VK_DOWN) & 0x8000)
 	{
 		//right mouse button
 		vector<unsigned short> utf16line;
 		utf8::utf8to16(m_textArea.text.begin(), m_textArea.text.end(), back_inserter(utf16line));
 		SetClipboardTextW(&utf16line[0], utf16line.size());
-		ShowQuickMessage("Copied text to clipboard");
+		ShowQuickMessage("Copied original text to clipboard");
+		return;
+	}
+	else if (! (GetKeyState(VK_SHIFT) & 0x8000))
+	{
+		//right mouse button
+		vector<unsigned short> utf16line;
+		utf8::utf8to16(m_translatedString.begin(), m_translatedString.end(), back_inserter(utf16line));
+		SetClipboardTextW(&utf16line[0], utf16line.size());
+		ShowQuickMessage("Copied translated text to clipboard");
 		return;
 	}
 	else


### PR DESCRIPTION
I'm trying to copy text from a game, where the translated text is more useful for me than the original text, so I'd like to add the possibility to copy either the translated or the original text.

Controls were chosen to match what is shown on screen, i.e. holding the down arrow key shows the untranslated text, so holding down + right click copies that untranslated text, whereas a normal right click copies the translated text.